### PR TITLE
chore: add renovate configuration

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
+  // Extend Renovate's recommended configuration and GitHub Actions digest pinning
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
+  ],
+
+  // Timezone configuration
+  "timezone": "Asia/Tokyo",
+
+  // Labels to apply to pull requests
+  "labels": ["A-dependencies"],
+
+  // Wait 7 days after a new version is released before creating a PR
+  "minimumReleaseAge": "7 days",
+
+  // No limit on the number of concurrent PRs
+  "prConcurrentLimit": 0,
+
+  // Enable vulnerability alerts (ignores minimumReleaseAge for security updates)
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+
+  // Package-specific rules for grouping updates by dependency type
+  "packageRules": [
+    {
+      // Cargo: group minor/patch updates together (major updates get individual PRs)
+      "matchManagers": ["cargo"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Cargo non-major dependencies"
+    },
+    {
+      // GitHub Actions: group minor/patch updates together (major updates get individual PRs)
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "GitHub Actions non-major updates"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR introduces Renovate configuration to automate dependency updates for this project. The project currently has outdated dependencies (e.g., clap 2.33.0 from 2019), and this configuration will help keep them up-to-date systematically.

**Configuration highlights:**

- **Dependency grouping strategy:**
  - Major updates: Individual PRs for careful review
  - Minor/patch updates: Grouped by package manager type (Cargo dependencies and GitHub Actions separately)

- **Safety mechanisms:**
  - `minimumReleaseAge: 7 days` - Wait 7 days after new releases for stability
  - `vulnerabilityAlerts: enabled` - Security updates bypass the waiting period
  - `helpers:pinGitHubActionDigests` preset - Maintain hash-based pinning for GitHub Actions

- **No PR limit:** `prConcurrentLimit: 0` allows unlimited concurrent PRs to handle the initial backlog of outdated dependencies

- **Labels:** All PRs will be tagged with `A-dependencies` for easy filtering

**Expected behavior after enabling Renovate:**

1. Individual PRs for major updates (e.g., clap 2.x → 4.x)
2. Grouped PR for Cargo minor/patch updates
3. Grouped PR for GitHub Actions minor/patch updates

All PRs require manual review and approval (no auto-merge).

## References

- [Renovate Documentation](https://docs.renovatebot.com/)
- [helpers:pinGitHubActionDigests preset](https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigests)
- [config:recommended preset](https://docs.renovatebot.com/presets-config/#configrecommended)