### PR TITLE
feat: change EdaMarkedNode highlight to yellow + bold

### DIFF
--- a/colors/dogrun.vim
+++ b/colors/dogrun.vim
@@ -270,7 +270,7 @@ hi EdaGitConflict guifg=#c09b92 ctermfg=138 gui=NONE cterm=NONE
 hi EdaGitConflictIcon guifg=#c09b92 ctermfg=138 gui=NONE cterm=NONE
 hi EdaGitIgnored guifg=#545c8c ctermfg=60 gui=NONE cterm=NONE
 hi EdaGitIgnoredIcon guifg=#545c8c ctermfg=60 gui=NONE cterm=NONE
-hi EdaMarkedNode guibg=#363e7f ctermbg=61 gui=NONE cterm=NONE
+hi EdaMarkedNode guifg=#a8a384 ctermfg=144 gui=bold cterm=bold
 hi EdaCut guifg=#545c8c ctermfg=60 gui=italic cterm=italic
 hi EdaOpDeleteSign guifg=#ff9494 ctermfg=210 gui=bold cterm=bold
 hi EdaOpDeletePath guifg=#ff9494 ctermfg=210 gui=NONE cterm=NONE

--- a/generator/src/highlight.rs
+++ b/generator/src/highlight.rs
@@ -668,7 +668,7 @@ pub fn get_highlights() -> Vec<Highlight> {
         hi!("EdaGitIgnored", weakfg, -, -, None, -),
         hi!("EdaGitIgnoredIcon", weakfg, -, -, None, -),
         // Operations
-        hi!("EdaMarkedNode", -, visualbg, -, None, -),
+        hi!("EdaMarkedNode", yellow, -, -, Bold, -),
         hi!("EdaCut", weakfg, -, -, Italic, -),
         hi!("EdaOpDeleteSign", red, -, -, Bold, -),
         hi!("EdaOpDeletePath", red, -, -, None, -),


### PR DESCRIPTION
## Summary

Change `EdaMarkedNode` from a `visualbg` background-only definition to a `yellow` foreground with `bold`. The previous definition was effectively invisible at runtime because eda.nvim strips the background during its setup, leaving marked entries with no visual distinction. The new definition gives marked files and their icons a clear, distinct appearance.

## References

- n/a
