### PR TITLE
fix: rename EdaMarkedNode highlight to EdaMarked

### DIFF
--- a/colors/dogrun.vim
+++ b/colors/dogrun.vim
@@ -270,7 +270,7 @@ hi EdaGitConflict guifg=#c09b92 ctermfg=138 gui=NONE cterm=NONE
 hi EdaGitConflictIcon guifg=#c09b92 ctermfg=138 gui=NONE cterm=NONE
 hi EdaGitIgnored guifg=#545c8c ctermfg=60 gui=NONE cterm=NONE
 hi EdaGitIgnoredIcon guifg=#545c8c ctermfg=60 gui=NONE cterm=NONE
-hi EdaMarkedNode guifg=#a8a384 ctermfg=144 gui=bold cterm=bold
+hi EdaMarked guifg=#a8a384 ctermfg=144 gui=bold cterm=bold
 hi EdaCut guifg=#545c8c ctermfg=60 gui=italic cterm=italic
 hi EdaOpDeleteSign guifg=#ff9494 ctermfg=210 gui=bold cterm=bold
 hi EdaOpDeletePath guifg=#ff9494 ctermfg=210 gui=NONE cterm=NONE

--- a/generator/src/highlight.rs
+++ b/generator/src/highlight.rs
@@ -668,7 +668,7 @@ pub fn get_highlights() -> Vec<Highlight> {
         hi!("EdaGitIgnored", weakfg, -, -, None, -),
         hi!("EdaGitIgnoredIcon", weakfg, -, -, None, -),
         // Operations
-        hi!("EdaMarkedNode", yellow, -, -, Bold, -),
+        hi!("EdaMarked", yellow, -, -, Bold, -),
         hi!("EdaCut", weakfg, -, -, Italic, -),
         hi!("EdaOpDeleteSign", red, -, -, Bold, -),
         hi!("EdaOpDeletePath", red, -, -, None, -),


### PR DESCRIPTION
## Summary

Rename the `EdaMarkedNode` highlight group to `EdaMarked` to match eda.nvim's actual highlight group name.

## References

- Follow-up to #43
